### PR TITLE
Fix up EOF detection and index out of range error on Windows systems

### DIFF
--- a/georeverse/offline_country_reverse.go
+++ b/georeverse/offline_country_reverse.go
@@ -81,6 +81,9 @@ func (c *CountryReverser) load(filePath string) error {
 	var line string
 	for {
 		line, err = rd.ReadString('\n')
+		if io.EOF == err {
+			break
+		}
 		line = strings.TrimSpace(line)
 		info := strings.SplitN(line, "=", 2)
 		countryCode := info[0]
@@ -100,9 +103,6 @@ func (c *CountryReverser) load(filePath string) error {
 				polyInfo.PointList = stringToListOfPoints(p)
 				c.allCountryPolygonInfo = append(c.allCountryPolygonInfo, polyInfo)
 			}
-		}
-		if io.EOF == err {
-			break
 		}
 	}
 	return nil


### PR DESCRIPTION
The io.EOF test needs to happen immediately after the ReadString() in
order to avoid iterating with data past the end of the file. The current
implementation blows up on Windows systems as follows:

panic: runtime error: index out of range

goroutine 1 [running]:
reverse-geocoding-service/vendor/github.com/AsGz/geo/georeverse.(*CountryReverser).load(0xc000044400, 0x4cfc33, 0x18, 0x0, 0x0)
	C:/.../vendor/github.com/AsGz/geo/georeverse/offline_country_reverse.go:88 +0x7d9
reverse-geocoding-service/vendor/github.com/AsGz/geo/georeverse.NewCountryReverser(0x4cfc33, 0x18, 0x4b50a0, 0xc00006ff01, 0xc00003e270)
	C:/.../vendor/github.com/AsGz/geo/georeverse/offline_country_reverse.go:59 +0x5b
main.main()
	C:/.../main.go:11 +0x4f

Process finished with exit code 2